### PR TITLE
Handle token limit retry

### DIFF
--- a/src/cogs/events_cog.py
+++ b/src/cogs/events_cog.py
@@ -10,7 +10,8 @@ import json
 from logging import getLogger
 from types import SimpleNamespace
 
-from langchain_core.messages import ToolMessage
+from langchain_core.messages import ToolMessage, SystemMessage
+from langchain_openai import ChatOpenAI
 
 logger = getLogger(__name__)
 
@@ -43,6 +44,8 @@ class EventsCog(commands.Cog):
     self.leave_message = os.getenv('VOICE_LEAVE_MESSAGE', '{name}が{channel}からきえてくにゃ・・・')
     self.join_message = os.getenv('VOICE_JOIN_MESSAGE', '{name}が{channel}に入ったにゃ！')
     self.notification_channel_name = os.getenv('VOICE_NOTIFICATION_CHANNEL', 'general')  # 通知先チャンネル名
+    self.initial_max_tokens = int(os.getenv('OPEN_AI_MAX_TOKEN', '0'))
+    self.current_max_tokens = self.initial_max_tokens
 
 
   @commands.Cog.listener()
@@ -211,6 +214,43 @@ class EventsCog(commands.Cog):
       new_messages = final_state['messages'][len(conversation_messages):]
       conversation_messages.extend(new_messages)
       last_message = conversation_messages[-1]
+
+      finish_reason = None
+      if hasattr(last_message, "response_metadata"):
+        finish_reason = last_message.response_metadata.get("finish_reason")
+      if finish_reason == "length":
+        logger.warning("Token limit reached. Increasing max_tokens by 10% and retrying without tools.")
+        if conversation_messages:
+          conversation_messages.pop()
+        new_max = int(self.current_max_tokens * 1.1) if self.current_max_tokens else 0
+        cap = int(self.initial_max_tokens * 2)
+        if new_max > cap:
+          new_max = cap
+          logger.info(f"max_tokens increase capped at {cap}")
+        if new_max > self.current_max_tokens:
+          logger.info(f"Updating max_tokens: {self.current_max_tokens} -> {new_max}")
+          self.current_max_tokens = new_max
+          if hasattr(self.bot.meowgent.model, "max_tokens"):
+            self.bot.meowgent.model.max_tokens = self.current_max_tokens
+          if hasattr(self.bot.meowgent.model, "model_kwargs"):
+            self.bot.meowgent.model.model_kwargs["max_tokens"] = self.current_max_tokens
+        else:
+          logger.info(f"max_tokens remains at {self.current_max_tokens}")
+        system_prompt = SystemMessage(content=self.bot.meowgent.system_prompt)
+        channel_prompt = SystemMessage(content=f"current_channel_id: {message.channel.id}")
+        fallback_model = ChatOpenAI(
+          model=os.getenv('OPEN_AI_MODEL'),
+          openai_api_key=os.getenv('OPEN_AI_API_KEY'),
+          openai_api_base=os.getenv('OPEN_AI_API_URL'),
+          max_tokens=self.current_max_tokens,
+          temperature=float(os.getenv('TEMPERATURE', 1))
+        )
+        response = fallback_model.invoke([system_prompt, channel_prompt] + conversation_messages)
+        conversation_messages.append(response)
+        reply_text = self.safe_text_from_content(response.content)
+        mock_msg = SimpleNamespace(author=self.bot.user, channel=message.channel, content=reply_text, attachments=[])
+        self.add_message_to_history(mock_msg, role="assistant")
+        break
 
       # ツール呼び出しがある場合、実行して再試行
       if getattr(last_message, "tool_calls", None):

--- a/src/cogs/events_cog.py
+++ b/src/cogs/events_cog.py
@@ -230,10 +230,10 @@ class EventsCog(commands.Cog):
         if new_max > self.current_max_tokens:
           logger.info(f"Updating max_tokens: {self.current_max_tokens} -> {new_max}")
           self.current_max_tokens = new_max
-          if hasattr(self.bot.meowgent.model, "max_tokens"):
-            self.bot.meowgent.model.max_tokens = self.current_max_tokens
-          if hasattr(self.bot.meowgent.model, "model_kwargs"):
-            self.bot.meowgent.model.model_kwargs["max_tokens"] = self.current_max_tokens
+          try:
+            self.bot.meowgent.model = self.bot.meowgent.model.bind(max_tokens=self.current_max_tokens)
+          except Exception as e:
+            logger.warning(f"Failed to rebind model with new max_tokens: {e}")
         else:
           logger.info(f"max_tokens remains at {self.current_max_tokens}")
         system_prompt = SystemMessage(content=self.bot.meowgent.system_prompt)


### PR DESCRIPTION
## Summary
- detect token limit overflow via finish_reason and retry with a larger max_tokens
- cap token expansion to 2x the original and log the change
- reuse same conversation history with an unbound ChatOpenAI instance for the final reply

## Testing
- `python3 -m py_compile src/cogs/events_cog.py`
- `python3 -m pytest` *(fails: No module named pytest; attempted installation but network/proxy prevented download)*

------
https://chatgpt.com/codex/tasks/task_e_6899ea62a8d08330895ac12aefc5551f